### PR TITLE
[WIP] Implement createSelector for optimized selectors

### DIFF
--- a/src/OptimizationQueue.js
+++ b/src/OptimizationQueue.js
@@ -1,0 +1,164 @@
+/**
+ *
+ * A priority queue that enforces unique elements, allows for updating
+ * the weight of existing key, and runs optimization and deoptimization routines when
+ * an element enters or leaves a range from the top of the heap to the nth index.
+ *
+ * @flow
+ * @format
+ */
+
+import invariant from 'invariant';
+
+type Comparator<T> = (T, T) => boolean;
+
+// Indicies between 1 and 29 are considered optimized slots (index
+// 0 is just null, to make the heapify routines simpler)
+// When a selector moves above index 29 it will be optimized.
+// If it drops below, it will be deoptimized.
+const OPTIMIZATION_THRESHOLD = 29;
+const MAX_SIGNED_31_BIT_INT = 1073741823;
+const DEOPTIMIZED_SELECTOR = 1;
+
+export default class OptimizationQueue<T> {
+  comparator: Comparator<T>;
+  _heap: Array<T>;
+  constructor(comparator: Comparator<T>) {
+    this.comparator = comparator;
+    this._heap = [null];
+    // The number of references for a given selector.
+    // Used in bubbleUp/bubbleDown to determine the heap ordering
+    this._referenceCounts = new Map();
+    // Track the index of each selector, so that when the priority
+    // changes we can just swap that selector with the first and then
+    // bubble it down.
+    this._indicies = new Map();
+    this._bits = [];
+    let bit = 2;
+    while (bit < MAX_SIGNED_31_BIT_INT) {
+      this._bits.push(bit);
+      bit <<= 1;
+    }
+  }
+
+  forEach(fn) {
+    let i = 1;
+    let selector = this._heap[i];
+    while (selector && i <= OPTIMIZATION_THRESHOLD) {
+      fn(selector);
+      i++;
+      selector = this._heap[i];
+    }
+  }
+
+  // Updates the tracked index and also runs the de/optimization
+  _setIndex(fn: T, index: number) {
+    if (
+      index > OPTIMIZATION_THRESHOLD &&
+      fn.observedBits !== DEOPTIMIZED_SELECTOR
+    ) {
+      this._bits.push(fn.observedBits);
+      fn.observedBits = DEOPTIMIZED_SELECTOR;
+    }
+    // unoptimized selector has moved into the top 29 selectors, optimize it
+    if (
+      index <= OPTIMIZATION_THRESHOLD &&
+      fn.observedBits === DEOPTIMIZED_SELECTOR
+    ) {
+      const bits = this._bits.pop();
+      fn.observedBits = bits;
+    }
+    this._indicies.set(fn, index);
+  }
+
+  _comparator(a, b) {
+    return this._referenceCounts.get(a) > this._referenceCounts.get(b);
+  }
+
+  reference(fn: T) {
+    if (this._referenceCounts.has(fn)) {
+      const index = this._indicies.get(fn);
+      // If the selector is already in the queue, we need
+      // to increment it's reference count.
+      let referenceCount = this._referenceCounts.get(fn);
+      this._referenceCounts.set(fn, referenceCount + 1);
+      this.bubbleUp(index);
+    } else {
+      // There have been no references to this selector yet,
+      // register the first reference in _referenceCounts and
+      // insert it into the heap.
+      this._referenceCounts.set(fn, 1);
+      const index = this._heap.push(fn) - 1;
+      this._setIndex(fn, index);
+      this.bubbleUp(this._heap.length - 1);
+    }
+  }
+
+  // Used to decrement the reference count for a selector.
+  // If the reference count ends up being zero, the selector
+  // should be removed from the queue entirely.
+  dereference(fn: T) {
+    const index = this._indicies.get(fn);
+    invariant(
+      typeof index !== 'undefined',
+      'Attempted to dereference a selector with no references',
+    );
+    invariant(
+      this._heap[index] === fn,
+      'The tracked index for a selector didnt match its actual index. ',
+    );
+    let referenceCount = this._referenceCounts.get(fn);
+    referenceCount--;
+    if (referenceCount === 0) {
+      // No more references, stop tracking the selector
+    } else {
+      // Update reference count and then reapply the heap invariant
+      this._referenceCounts.set(fn, referenceCount);
+      this.bubbleDown(index);
+    }
+  }
+
+  bubbleDown(index: number): void {
+    const heap = this._heap;
+    const length = heap.length;
+    const left = index * 2;
+    const right = left + 1;
+    let swap = null;
+    if (right < length && this._comparator(heap[right], heap[index])) {
+      swap = right;
+    }
+    if (
+      left < length &&
+      this._comparator(heap[left], swap ? heap[swap] : heap[index])
+    ) {
+      swap = left;
+    }
+    if (swap !== null) {
+      this._setIndex(element, swap);
+      this._setIndex(heap[swap], index);
+      const element = heap[index];
+      heap[index] = heap[swap];
+      heap[swap] = element;
+      this.bubbleDown(swap);
+    }
+  }
+
+  bubbleUp(index: number): void {
+    const heap = this._heap;
+    const element = heap[index];
+    // We stop at index 1 as the first element.
+    while (index > 1) {
+      const parentIndex = Math.floor(index / 2);
+      const parent = heap[parentIndex];
+      if (this._comparator(element, parent)) {
+        this._setIndex(parent, index);
+        this._setIndex(element, parentIndex);
+        heap[index] = parent;
+        heap[parentIndex] = element;
+        index = parentIndex;
+      } else {
+        break;
+      }
+    }
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -54,7 +54,7 @@ function getObservedBitsForSelector(selector): number {
   if (typeof selector.observedBits === "number") {
     return selector.observedBits;
   }
-  return MAX_SIGNED_31_BIT_INT;
+  return DEOPTIMIZED_SELECTOR;
 }
 
 function getObservedBits<T, S>(selector: Selector<T, S>): number {
@@ -100,7 +100,7 @@ export default function createCopyOnWriteState<T>(baseState: T) {
     }
     let referenceCount = selectorReferenceCount.get(selector) || 0;
     selectorReferenceCount.set(selector, referenceCount + 1);
-    if (selector.observedBits !== MAX_SIGNED_31_BIT_INT) {
+    if (selector.observedBits !== DEOPTIMIZED_SELECTOR) {
       // This selector is already optimized
       return;
     }

--- a/src/index.js
+++ b/src/index.js
@@ -39,13 +39,118 @@ type ConsumerCallback<T, S> = (ObservedState<S>, Updater<T>) => React$Node;
  * is defined by ObservedState.
  */
 type Selector<T, S> = T => ObservedState<S>;
+type OptimizedSelector<T, S> = { id: number, fn: Selector<T, S> };
+
+// changedBits
+const MAX_SIGNED_31_BIT_INT = 1073741823;
+const DEOPTIMIZED_SELECTOR = 1;
 
 // The default selector is the identity function
 function identityFn<T>(n: T): T {
   return n;
 }
 
+function getObservedBitsForSelector(selector): number {
+  if (typeof selector.observedBits === "number") {
+    return selector.observedBits;
+  }
+  return MAX_SIGNED_31_BIT_INT;
+}
+
+function getObservedBits<T, S>(selector: Selector<T, S>): number {
+  return Array.isArray(selector)
+    ? selector.reduce(
+        (bits, selector) => bits | getObservedBitsForSelector(selector),
+        0
+      )
+    : getObservedBitsForSelector(selector);
+}
+
 export default function createCopyOnWriteState<T>(baseState: T) {
+  // There are 30 unique bit values, allowing for 30 optimized selectors
+  // at any given time. Since these bits can be dynamically allocated and released
+  // as Consumers mount and unmount, respectively, we model it as a stack of constant
+  // values.
+  let selectorBits = [];
+  let bit = 2;
+  while (bit < MAX_SIGNED_31_BIT_INT) {
+    selectorBits.push(bit);
+    bit <<= 1;
+  }
+  // Selectors which are optimizable are queued here when we attempt to optimize a selector,
+  // but there are no more slots available.
+  const optimizationQueue = [];
+  /**
+   * For optimizable selectors, we need to track how many Consumers are currently
+   * referencing it. That way we know whether we can de-optimize it when a consumer
+   * unmounts, freeing up a slot for a new selector.
+   */
+  const selectorReferenceCount = new Map();
+  /**
+   * We also need to know which selectors are current optimized. This may not always
+   * be the same set of selectors in the selectorReferenceCount map, as we want to track
+   * reference count for selectors that are queued to be optimized as well.
+   */
+  const optimizedSelectors = new Set();
+
+  function optimizeSelector(selector) {
+    if (typeof selector.observedBits !== "number") {
+      // An unknown selector, we can never optimize these. Ignore it.
+      return;
+    }
+    let referenceCount = selectorReferenceCount.get(selector) || 0;
+    selectorReferenceCount.set(selector, referenceCount + 1);
+    if (selector.observedBits !== MAX_SIGNED_31_BIT_INT) {
+      // This selector is already optimized
+      return;
+    }
+    if (!selectorBits.length) {
+      // The selector isn't optimized, but there's no more slots. Queue it
+      // up to be optimized.
+      optimizationQueue.push(selector);
+      return;
+    }
+    // The selector isn't optimized and there are open slots. Register it as an
+    // optimized selector!
+    selector.observedBits = selectorBits.pop();
+    optimizedSelectors.add(selector);
+  }
+
+  function deoptimizeSelector(selector) {
+    if (typeof selector.observedBits !== "number") {
+      return;
+    }
+    // This selector was never optimized. It's likely in the queue, waiting to
+    // be optimized. Ignore it for now.
+    if (optimizedSelectors.has(selector)) {
+      return;
+    }
+    let referenceCount = selectorReferenceCount.get(selector);
+    // referenceCount should always exist, and be greather than 0
+    invariant(
+      typeof referenceCount !== "undefined" && referenceCount > 0,
+      "react-copy-write: attempted to deoptimize a selector that was never " +
+        "optimized. This is likey a bug with react-copy-write"
+    );
+    referenceCount--;
+    // No more references to this selector, it should be de-optimized.
+    if (referenceCount === 0) {
+      // Free up a slot so a queued selector can be optimized.
+      selectorBits.push(selector.observedBits);
+      selector.observedBits = DEOPTIMIZED_SELECTOR;
+      selectorReferenceCount.delete(selector);
+      optimizedSelectors.delete(selector);
+      if (optimizationQueue.length) {
+        // TODO we should choose the selector to optimize based on its reference count.
+        const selector = optimizationQueue.pop();
+        optimizeSelector(selector);
+      }
+    } else {
+      // De-prioritize this selector by updating its reduced reference count
+      selectorReferenceCount.set(selector, referenceCount);
+    }
+  }
+
   /**
    * The current state is stored in a closure, shared by the consumers and
    * the provider. Consumers still respect the Provider/Consumer contract
@@ -54,7 +159,16 @@ export default function createCopyOnWriteState<T>(baseState: T) {
   let currentState: T = baseState;
   let providerListener = null;
   // $FlowFixMe React.createContext exists now
-  const State = React.createContext(baseState);
+  const State = React.createContext(baseState, (stale: T, current: T) => {
+    let changedBits = DEOPTIMIZED_SELECTOR;
+    optimizedSelectors.forEach((bits, selector) => {
+      if (selector(stale) !== selector(current)) {
+        changedBits |= bits;
+      }
+    });
+    return changedBits;
+  });
+
   // Wraps immer's produce. Only notifies the Provider
   // if the returned draft has been changed.
   function update(fn: UpdateFn<T>) {
@@ -77,12 +191,23 @@ export default function createCopyOnWriteState<T>(baseState: T) {
    * to calling mutate(...) directly, except you can define it statically,
    * and have any additional arguments forwarded.
    */
-  function createMutator(fn: UpdateFn<T>)  {
+  function createMutator(fn: UpdateFn<T>) {
     return (...args: mixed[]) => {
       update(draft => {
         fn(draft, ...args);
-      })
-    }
+      });
+    };
+  }
+
+  function createSelector<S>(fn: T => S) {
+    // When an optimized selector is created, it isn't initially optimized.
+    // Once it's actually used in a Consumer that mounts, observedBits will be updated
+    // with a bit flag popped off the selectorBits stack. If selectorBits is empty,
+    // that indicates there are already 30 optimized selectors in use, in which case this
+    // selector will be treated as unoptimized. It will be added to a queue of optimizable selectors
+    // that are waiting for some other selector to unmount.
+    fn.observedBits = DEOPTIMIZED_SELECTOR;
+    return fn;
   }
 
   class CopyOnWriteStoreProvider extends React.Component<
@@ -147,13 +272,6 @@ export default function createCopyOnWriteState<T>(baseState: T) {
       selector: identityFn
     };
 
-    getObservedState(state: T, selectors: Selector<T, S>): ObservedState<S> {
-      if (Array.isArray(selectors)) {
-        return selectors.map(fn => fn(state));
-      }
-      return selectors(state);
-    }
-
     consumer = (state: T) => {
       const { children, selector } = this.props;
       const observedState = this.getObservedState(state, selector);
@@ -164,8 +282,30 @@ export default function createCopyOnWriteState<T>(baseState: T) {
       );
     };
 
+    getObservedState(state: T, selectors: Selector<T, S>): ObservedState<S> {
+      if (Array.isArray(selectors)) {
+        return selectors.map(selector => selector(state));
+      }
+      return selectors(state);
+    }
+
+    componentDidMount() {
+      const selectors = [].concat(this.props.selector);
+      selectors.forEach(optimizeSelector);
+    }
+
+    componentWillUnmount() {
+      const selectors = [].concat(this.props.selector);
+      selectors.forEach(deoptimizeSelector);
+    }
+
     render() {
-      return <State.Consumer>{this.consumer}</State.Consumer>;
+      const observedBits = getObservedBits(this.props.selector);
+      return (
+        <State.Consumer unstable_observedBits={observedBits}>
+          {this.consumer}
+        </State.Consumer>
+      );
     }
   }
 
@@ -187,6 +327,7 @@ export default function createCopyOnWriteState<T>(baseState: T) {
     Consumer: CopyOnWriteConsumer,
     Mutator: CopyOnWriteMutator,
     update,
-    createMutator
+    createMutator,
+    createSelector
   };
 }

--- a/src/index.js
+++ b/src/index.js
@@ -122,7 +122,7 @@ export default function createCopyOnWriteState<T>(baseState: T) {
     }
     // This selector was never optimized. It's likely in the queue, waiting to
     // be optimized. Ignore it for now.
-    if (optimizedSelectors.has(selector)) {
+    if (!optimizedSelectors.has(selector)) {
       return;
     }
     let referenceCount = selectorReferenceCount.get(selector);

--- a/src/index.js
+++ b/src/index.js
@@ -82,26 +82,6 @@ function getObservedBits<T, S>(selector: Selector<T, S>): number {
     : getObservedBitsForSelector(selector);
 }
 
-/**
- * Used to determine which queued selector can be optimized. Currently runs in O(n)
- * where n is the number of queued selectors. Ideally there should never be more than
- * a few dozen optimized selectors, but it's possible users might create 100s or 1000s
- * if they're defining the selector as an instance property. With that in mind, it might
- * be worth using a priority heap to get O(log n) performance.
- */
-function getHighestPrioritySelector(queue, referenceCountMap) {
-  let highestReferenceCount = 0;
-  let prioritizedSelector;
-  for (let i = 0; i < queue.length; i++) {
-    const selector = queue[i];
-    const referenceCount = referenceCountMap.get(selector);
-    if (referenceCount > highestReferenceCount) {
-      highestReferenceCount = referenceCount;
-      prioritizedSelector = selector;
-    }
-  }
-}
-
 export default function createCopyOnWriteState<T>(baseState: T) {
   const queue = new OptimizationQueue();
 

--- a/src/index.js
+++ b/src/index.js
@@ -12,10 +12,13 @@
  * by immer and React.createContext.
  *
  * @flow
+ * @format
  */
-import React, { Component } from "react";
-import produce from "immer";
-import invariant from "invariant";
+import React, {Component} from 'react';
+import produce from 'immer';
+import invariant from 'invariant';
+
+import OptimizationQueue from './OptimizationQueue.js';
 
 // Update functions take the current state, mutate it, and return nothing (undefined)
 type UpdateFn<T> = T => void;
@@ -39,10 +42,12 @@ type ConsumerCallback<T, S> = (ObservedState<S>, Updater<T>) => React$Node;
  * is defined by ObservedState.
  */
 type Selector<T, S> = T => ObservedState<S>;
-type OptimizedSelector<T, S> = { id: number, fn: Selector<T, S> };
+type OptimizedSelector<T, S> = {id: number, fn: Selector<T, S>};
 
-// changedBits
-const MAX_SIGNED_31_BIT_INT = 1073741823;
+/**
+ * If a selector is observing DEOPTIMIZED_SELECTOR, it will always
+ * update the consumer
+ */
 const DEOPTIMIZED_SELECTOR = 1;
 
 // The default selector is the identity function
@@ -50,8 +55,19 @@ function identityFn<T>(n: T): T {
   return n;
 }
 
+function createSelector<S>(fn: T => S) {
+  // When an optimized selector is created, it isn't initially optimized.
+  // Once it's actually used in a Consumer that mounts, observedBits will be updated
+  // with a bit flag popped off the selectorBits stack. If selectorBits is empty,
+  // that indicates there are already 30 optimized selectors in use, in which case this
+  // selector will be treated as unoptimized. It will be added to a queue of optimizable selectors
+  // that are waiting for some other selector to unmount.
+  fn.observedBits = DEOPTIMIZED_SELECTOR;
+  return fn;
+}
+
 function getObservedBitsForSelector(selector): number {
-  if (typeof selector.observedBits === "number") {
+  if (typeof selector.observedBits === 'number') {
     return selector.observedBits;
   }
   return DEOPTIMIZED_SELECTOR;
@@ -61,94 +77,47 @@ function getObservedBits<T, S>(selector: Selector<T, S>): number {
   return Array.isArray(selector)
     ? selector.reduce(
         (bits, selector) => bits | getObservedBitsForSelector(selector),
-        0
+        0,
       )
     : getObservedBitsForSelector(selector);
 }
 
-export default function createCopyOnWriteState<T>(baseState: T) {
-  // There are 30 unique bit values, allowing for 30 optimized selectors
-  // at any given time. Since these bits can be dynamically allocated and released
-  // as Consumers mount and unmount, respectively, we model it as a stack of constant
-  // values.
-  let selectorBits = [];
-  let bit = 2;
-  while (bit < MAX_SIGNED_31_BIT_INT) {
-    selectorBits.push(bit);
-    bit <<= 1;
+/**
+ * Used to determine which queued selector can be optimized. Currently runs in O(n)
+ * where n is the number of queued selectors. Ideally there should never be more than
+ * a few dozen optimized selectors, but it's possible users might create 100s or 1000s
+ * if they're defining the selector as an instance property. With that in mind, it might
+ * be worth using a priority heap to get O(log n) performance.
+ */
+function getHighestPrioritySelector(queue, referenceCountMap) {
+  let highestReferenceCount = 0;
+  let prioritizedSelector;
+  for (let i = 0; i < queue.length; i++) {
+    const selector = queue[i];
+    const referenceCount = referenceCountMap.get(selector);
+    if (referenceCount > highestReferenceCount) {
+      highestReferenceCount = referenceCount;
+      prioritizedSelector = selector;
+    }
   }
-  // Selectors which are optimizable are queued here when we attempt to optimize a selector,
-  // but there are no more slots available.
-  const optimizationQueue = [];
-  /**
-   * For optimizable selectors, we need to track how many Consumers are currently
-   * referencing it. That way we know whether we can de-optimize it when a consumer
-   * unmounts, freeing up a slot for a new selector.
-   */
-  const selectorReferenceCount = new Map();
-  /**
-   * We also need to know which selectors are current optimized. This may not always
-   * be the same set of selectors in the selectorReferenceCount map, as we want to track
-   * reference count for selectors that are queued to be optimized as well.
-   */
-  const optimizedSelectors = new Set();
+}
+
+export default function createCopyOnWriteState<T>(baseState: T) {
+  const queue = new OptimizationQueue();
 
   function optimizeSelector(selector) {
-    if (typeof selector.observedBits !== "number") {
+    if (typeof selector.observedBits !== 'number') {
       // An unknown selector, we can never optimize these. Ignore it.
       return;
     }
-    let referenceCount = selectorReferenceCount.get(selector) || 0;
-    selectorReferenceCount.set(selector, referenceCount + 1);
-    if (selector.observedBits !== DEOPTIMIZED_SELECTOR) {
-      // This selector is already optimized
-      return;
-    }
-    if (!selectorBits.length) {
-      // The selector isn't optimized, but there's no more slots. Queue it
-      // up to be optimized.
-      optimizationQueue.push(selector);
-      return;
-    }
-    // The selector isn't optimized and there are open slots. Register it as an
-    // optimized selector!
-    selector.observedBits = selectorBits.pop();
-    optimizedSelectors.add(selector);
+    queue.reference(selector);
   }
 
   function deoptimizeSelector(selector) {
-    if (typeof selector.observedBits !== "number") {
+    if (typeof selector.observedBits !== 'number') {
       return;
     }
-    // This selector was never optimized. It's likely in the queue, waiting to
-    // be optimized. Ignore it for now.
-    if (!optimizedSelectors.has(selector)) {
-      return;
-    }
-    let referenceCount = selectorReferenceCount.get(selector);
-    // referenceCount should always exist, and be greather than 0
-    invariant(
-      typeof referenceCount !== "undefined" && referenceCount > 0,
-      "react-copy-write: attempted to deoptimize a selector that was never " +
-        "optimized. This is likey a bug with react-copy-write"
-    );
-    referenceCount--;
-    // No more references to this selector, it should be de-optimized.
-    if (referenceCount === 0) {
-      // Free up a slot so a queued selector can be optimized.
-      selectorBits.push(selector.observedBits);
-      selector.observedBits = DEOPTIMIZED_SELECTOR;
-      selectorReferenceCount.delete(selector);
-      optimizedSelectors.delete(selector);
-      if (optimizationQueue.length) {
-        // TODO we should choose the selector to optimize based on its reference count.
-        const selector = optimizationQueue.pop();
-        optimizeSelector(selector);
-      }
-    } else {
-      // De-prioritize this selector by updating its reduced reference count
-      selectorReferenceCount.set(selector, referenceCount);
-    }
+    queue.dereference(selector);
   }
 
   /**
@@ -161,7 +130,7 @@ export default function createCopyOnWriteState<T>(baseState: T) {
   // $FlowFixMe React.createContext exists now
   const State = React.createContext(baseState, (stale: T, current: T) => {
     let changedBits = DEOPTIMIZED_SELECTOR;
-    optimizedSelectors.forEach((bits, selector) => {
+    queue.forEach((bits, selector) => {
       if (selector(stale) !== selector(current)) {
         changedBits |= bits;
       }
@@ -177,7 +146,7 @@ export default function createCopyOnWriteState<T>(baseState: T) {
       `update(...): you cannot call update when no CopyOnWriteStoreProvider ` +
         `instance is mounted. Make sure to wrap your consumer components with ` +
         `the returned Provider, and/or delay your update calls until the component ` +
-        `tree is moutned.`
+        `tree is moutned.`,
     );
     const nextState = produce(currentState, fn);
     if (nextState !== currentState) {
@@ -199,20 +168,9 @@ export default function createCopyOnWriteState<T>(baseState: T) {
     };
   }
 
-  function createSelector<S>(fn: T => S) {
-    // When an optimized selector is created, it isn't initially optimized.
-    // Once it's actually used in a Consumer that mounts, observedBits will be updated
-    // with a bit flag popped off the selectorBits stack. If selectorBits is empty,
-    // that indicates there are already 30 optimized selectors in use, in which case this
-    // selector will be treated as unoptimized. It will be added to a queue of optimizable selectors
-    // that are waiting for some other selector to unmount.
-    fn.observedBits = DEOPTIMIZED_SELECTOR;
-    return fn;
-  }
-
   class CopyOnWriteStoreProvider extends React.Component<
-    { children: React$Node },
-    T
+    {children: React$Node},
+    T,
   > {
     state = baseState;
 
@@ -220,7 +178,7 @@ export default function createCopyOnWriteState<T>(baseState: T) {
       invariant(
         providerListener === null,
         `CopyOnWriteStoreProvider(...): There can only be a single ` +
-          `instance of a provider rendered at any given time.`
+          `instance of a provider rendered at any given time.`,
       );
       providerListener = this.updateState;
     }
@@ -244,36 +202,36 @@ export default function createCopyOnWriteState<T>(baseState: T) {
 
   class ConusmerIndirection<S> extends React.Component<{
     children: ConsumerCallback<T, S>,
-    state: ObservedState<S>
+    state: ObservedState<S>,
   }> {
-    shouldComponentUpdate({ state }: { state: ObservedState<S> }) {
+    shouldComponentUpdate({state}: {state: ObservedState<S>}) {
       if (Array.isArray(state)) {
         // Assumes that if nextProps.state is an array, then the this.props.state is also
         // an array.
         const currentState = ((this.props.state: any): Array<S>);
         return state.some(
-          (observedState, i) => observedState !== currentState[i]
+          (observedState, i) => observedState !== currentState[i],
         );
       }
       return this.props.state !== state;
     }
 
     render() {
-      const { children, state } = this.props;
+      const {children, state} = this.props;
       return children(state, update);
     }
   }
 
   class CopyOnWriteConsumer<S> extends React.Component<{
     selector: Selector<T, S>,
-    children: ConsumerCallback<T, S>
+    children: ConsumerCallback<T, S>,
   }> {
     static defaultProps = {
-      selector: identityFn
+      selector: identityFn,
     };
 
     consumer = (state: T) => {
-      const { children, selector } = this.props;
+      const {children, selector} = this.props;
       const observedState = this.getObservedState(state, selector);
       return (
         <ConusmerIndirection state={observedState}>
@@ -315,7 +273,7 @@ export default function createCopyOnWriteState<T>(baseState: T) {
    * state, but doesn't care about what the current state is
    */
   class CopyOnWriteMutator extends React.Component<{
-    children: (Updater<T>) => React$Node
+    children: (Updater<T>) => React$Node,
   }> {
     render() {
       return this.props.children(update);
@@ -328,6 +286,6 @@ export default function createCopyOnWriteState<T>(baseState: T) {
     Mutator: CopyOnWriteMutator,
     update,
     createMutator,
-    createSelector
+    createSelector,
   };
 }


### PR DESCRIPTION
This adds a new API, `createSelector`, that lets you define optimizable selectors. These selectors can be optimized using the `unstable_observedBits` React context API. This optimization strategy assumes that selectors, not consumers, are the basic abstraction for composability; since selectors can be re-used between consumers optimizing at the selector level is inherently more powerful.

These selectors are optimized using a heuristic based on the reference count for a given selector; the first 29 selectors used in mounted consumers are always optimized. After that, they get queued up for optimization. Once an optimized selector can be de-optimized (all the consumers using it unmount) it frees up a slot, and the queued selector with the highest reference count is optimized.

cc @gaearon

## TODO

- [ ] Write some tests
- [ ] Ensure queued selectors are removed once their reference count hits 0
- [ ] Use a better data structure for `optimizationQueue`
- [ ] Determine next selector to optimize based on reference count
- [ ] Dont increase reference count in `optimizeSelector`
- [ ] Should it avoid optimizing selectors when they are used alongside unoptimzed selectors? Those unoptimized seletors will force a de-opt anyways, so maybe save the slots?