### PR TITLE
doc: fix undeclared/unused variable in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ An immutable React state management library with a simple mutable API, memoized 
 [Check out this small demo.](https://codesandbox.io/s/yp34vpk50j)
 
 [![Build Status](https://travis-ci.org/aweary/react-copy-write.svg?branch=master)](https://travis-ci.org/aweary/react-copy-write)
-[![npm](https://img.shields.io/npm/v/react-copy-write.svg)](https://www.npmjs.com/package/react-copy-write) 
+[![npm](https://img.shields.io/npm/v/react-copy-write.svg)](https://www.npmjs.com/package/react-copy-write)
 [![license](https://img.shields.io/github/license/mashape/apistatus.svg)](https://github.com/aweary/react-copy-write/blob/master/LICENSE)
 
 
@@ -295,7 +295,7 @@ const SearchBar = () => (
   <div className="search-bar">
     <State.Consumer selector={state => state.search}>
     {(search) => (
-      <input value={state} onChange={setSearch} />
+      <input value={search} onChange={setSearch} />
     )}
     </State.Consumer>
   </div>


### PR DESCRIPTION
Fixes a small bug in README.
> the `<input>`'s value was assigned with `state` instead of `search`. But `state` was not declared there. The value is supposed to be `search`, right?

PS. also removed a trailing space on line 13  :P