### PR TITLE
Add ability to take in middleware

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+notifications:
+  email: false
+node_js: 'node'

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ An immutable React state management library with a simple mutable API, memoized 
 
 [Check out this small demo.](https://codesandbox.io/s/yp34vpk50j)
 
-[![Build Status](https://travis-ci.com/aweary/react-copy-write.svg?branch=master)](https://travis-ci.com/aweary/react-copy-write) 
+[![Build Status](https://travis-ci.org/aweary/react-copy-write.svg?branch=master)](https://travis-ci.org/aweary/react-copy-write)
 [![npm](https://img.shields.io/npm/v/react-copy-write.svg)](https://www.npmjs.com/package/react-copy-write) 
 [![license](https://img.shields.io/github/license/mashape/apistatus.svg)](https://github.com/aweary/react-copy-write/blob/master/LICENSE)
 

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ const SearchBar = () => (
     <State.Consumer selector={state => state.search}>
       {(search, mutate) => (
         <input
-          value={state}
+          value={search}
           onChange={event =>
             mutate(draft => {
               // Update draft.search (which will end up being state.search) via mutation

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ react-copy-write lets you use straightforward mutations to update an immutable s
   * [Composing Selectors](#composing-selectors)
   * [Applying Multiple Selectors](#applying-multiple-selectors)
 * [Updating State](#updating-state)
-  * [`createUpdater`](#createupdater)
+  * [`createMutator`](#createmutator)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ An immutable React state management library with a simple mutable API, memoized 
 [Check out this small demo.](https://codesandbox.io/s/yp34vpk50j)
 
 [![Build Status](https://travis-ci.org/aweary/react-copy-write.svg?branch=master)](https://travis-ci.org/aweary/react-copy-write)
-[![npm](https://img.shields.io/npm/v/react-copy-write.svg)](https://www.npmjs.com/package/react-copy-write) 
+[![npm](https://img.shields.io/npm/v/react-copy-write.svg)](https://www.npmjs.com/package/react-copy-write)
 [![license](https://img.shields.io/github/license/mashape/apistatus.svg)](https://github.com/aweary/react-copy-write/blob/master/LICENSE)
 
 
@@ -295,7 +295,7 @@ const SearchBar = () => (
   <div className="search-bar">
     <State.Consumer selector={state => state.search}>
     {(search) => (
-      <input value={state} onChange={setSearch} />
+      <input value={search} onChange={setSearch} />
     )}
     </State.Consumer>
   </div>

--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ An immutable React state management library with a simple mutable API, memoized 
 
 [Check out this small demo.](https://codesandbox.io/s/yp34vpk50j)
 
+[![Build Status](https://travis-ci.com/aweary/react-copy-write.svg?branch=master)](https://travis-ci.com/aweary/react-copy-write) 
+[![npm](https://img.shields.io/npm/v/react-copy-write.svg)](https://www.npmjs.com/package/react-copy-write) 
+[![license](https://img.shields.io/github/license/mashape/apistatus.svg)](https://github.com/aweary/react-copy-write/blob/master/LICENSE)
+
+
+
 </div>
 
 ## Overview

--- a/src/index.js
+++ b/src/index.js
@@ -63,7 +63,7 @@ export default function createCopyOnWriteState<T>(baseState: T) {
       `update(...): you cannot call update when no CopyOnWriteStoreProvider ` +
         `instance is mounted. Make sure to wrap your consumer components with ` +
         `the returned Provider, and/or delay your update calls until the component ` +
-        `tree is moutned.`
+        `tree is mounted.`
     );
     const nextState = produce(currentState, fn);
     if (nextState !== currentState) {


### PR DESCRIPTION
https://github.com/aweary/react-copy-write/issues/17
It looks as follows when being consumed.

```
import React from 'react';
import createState from 'react-copy-write';

const logger = getState => next => fn => {
  const state = getState();
  console.log('prev state', state);
  next(fn);
  console.log('next state', getState());
}

const crashReporter = getState => next => fn => {
  try {
    next(fn)
  } catch (err) {
    console.error('Caught an exception!', err)

    throw err
  }
}

const { Provider, Consumer, createMutator } = createState({
  count: 0
}, [crashReporter, logger])

const increment = createMutator(draft => draft.count = draft.count + 1);
const decrement = createMutator(draft => draft.count = draft.count - 1);


function Counter() {
  return (
    <Consumer>
      {state => (
        <div>
          <button onClick={decrement}>-</button>
          <span>{state.count}</span>
          <button onClick={increment}>+</button>
        </div>
      )}
    </Consumer>
  );
}

export default () => <Provider>
  <Counter />
</Provider>
```

What do you think? Need some TLC for typing and tests. 