### PR TITLE
Add initialState prop to Provider

### DIFF
--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -249,4 +249,36 @@ describe("copy-on-write-store", () => {
     removeItem(2);
     expect(log).toEqual(["1,1,2", "1,1"]);
   });
+
+  it("Providers can initialize state via props", () => {
+    const { Provider, Consumer, update: mutate } = createState({
+      items: [0]
+    });
+    const addItem = item => {
+      mutate(draft => {
+        draft.items.push(item);
+      });
+    };
+    let log = [];
+    const App = ({ initialState }) => (
+      <Provider initialState={initialState}>
+        <div>
+          <Consumer selector={state => state.items}>
+            {items => {
+              log.push(items.join());
+              return null;
+            }}
+          </Consumer>
+        </div>
+      </Provider>
+    );
+    const { rerender } = render(<App initialState={{ items: [1, 2, 3] }} />);
+    expect(log).toEqual(["1,2,3"]);
+    log = [];
+    rerender(<App initialState={{ items: [4, 5, 6] }} />);
+    // Log should be empty, since the consumer shouldn't re-render
+    expect(log).toEqual([]);
+    addItem(4);
+    expect(log).toEqual(["1,2,3,4"]);
+  });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-copy-write",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "main": "lib/index.js",
   "author": "Brandon Dail <brandondail@fb.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   },
   "dependencies": {
     "immer": "^1.2.1",
-    "invariant": "^2.2.4"
+    "invariant": "^2.2.4",
+    "react-testing-library": "^3.1.3"
   },
   "peerDependencies": {
     "react": "^16.3.0"
@@ -32,7 +33,6 @@
     "prettier": "^1.12.0",
     "react": "^16.3.1",
     "react-dom": "^16.3.1",
-    "react-testing-library": "^2.1.0",
     "regenerator-runtime": "^0.11.1"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -86,10 +86,10 @@ export default function createCopyOnWriteState<T>(baseState: T) {
   }
 
   class CopyOnWriteStoreProvider extends React.Component<
-    { children: React$Node },
+    { children: React$Node, initialState?: T },
     T
   > {
-    state = baseState;
+    state = this.props.initialState || baseState;
 
     componentDidMount() {
       invariant(
@@ -98,6 +98,10 @@ export default function createCopyOnWriteState<T>(baseState: T) {
           `instance of a provider rendered at any given time.`
       );
       providerListener = this.updateState;
+      // Allow a Provider to initialize state from props
+      if (this.props.initialState) {
+        currentState = this.props.initialState;
+      }
     }
 
     componentWillUnmount() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -788,6 +788,10 @@ atob@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.0.tgz#ab2b150e51d7b122b9efc8d7340c06b6c41076bc"
 
+atob@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.1.tgz#ae2d5a729477f289d60dd7f96a6314a22dd6c22a"
+
 aws-sign2@~0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.6.0.tgz#14342dd38dbcc94d0e5b87d763cd63612c0e794f"
@@ -1119,6 +1123,14 @@ chalk@^2.0.0, chalk@^2.0.1:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
+chalk@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
+  dependencies:
+    ansi-styles "^3.2.1"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.3.0"
+
 chokidar@^1.6.1:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-1.7.0.tgz#798e689778151c8076b4b360e5edd28cda2bb468"
@@ -1254,6 +1266,15 @@ cryptiles@3.x.x:
   dependencies:
     boom "5.x.x"
 
+css@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/css/-/css-2.2.3.tgz#f861f4ba61e79bedc962aa548e5780fd95cbc6be"
+  dependencies:
+    inherits "^2.0.1"
+    source-map "^0.1.38"
+    source-map-resolve "^0.5.1"
+    urix "^0.1.0"
+
 cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.2.tgz#b8036170c79f07a90ff2f16e22284027a243848b"
@@ -1364,9 +1385,9 @@ diff@^3.2.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
 
-dom-testing-library@^1.0.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/dom-testing-library/-/dom-testing-library-1.5.0.tgz#4cc2f3a672f7e3a024cba9694e8031e3fec87b8e"
+dom-testing-library@^2.3.1:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/dom-testing-library/-/dom-testing-library-2.5.0.tgz#68153181da258c9dd7df9d55cb5c3c71b6f4c8c9"
   dependencies:
     jest-dom "^1.0.0"
     mutationobserver-shim "^0.3.2"
@@ -1942,6 +1963,10 @@ imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
 
+indent-string@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-3.2.0.tgz#4a5fd6d27cc332f37e5419a504dbb837105c9289"
+
 inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
@@ -2337,10 +2362,15 @@ jest-docblock@^22.4.3:
     detect-newline "^2.1.0"
 
 jest-dom@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/jest-dom/-/jest-dom-1.0.0.tgz#775bbfc532e72adf6dfa589fc7cb057e196faff5"
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/jest-dom/-/jest-dom-1.3.1.tgz#4eba15d54059182ee0d3682a9fff0d957ad874c7"
   dependencies:
+    chalk "^2.4.1"
+    css "^2.2.3"
+    jest-diff "^22.4.3"
     jest-matcher-utils "^22.4.3"
+    pretty-format "^23.0.1"
+    redent "^2.0.0"
 
 jest-environment-jsdom@^22.4.3:
   version "22.4.3"
@@ -3161,6 +3191,13 @@ pretty-format@^22.4.3:
     ansi-regex "^3.0.0"
     ansi-styles "^3.2.0"
 
+pretty-format@^23.0.1:
+  version "23.0.1"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-23.0.1.tgz#d61d065268e4c759083bccbca27a01ad7c7601f4"
+  dependencies:
+    ansi-regex "^3.0.0"
+    ansi-styles "^3.2.0"
+
 private@^0.1.6, private@^0.1.7:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
@@ -3228,12 +3265,12 @@ react-dom@^16.3.1:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
-react-testing-library@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/react-testing-library/-/react-testing-library-2.1.0.tgz#b87b2c8b35fc786e93cc32f427aeb1f493701d69"
+react-testing-library@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/react-testing-library/-/react-testing-library-3.1.3.tgz#0b7ceaa1d5a13415b681e1769f1ba03f7f3f4794"
   dependencies:
-    dom-testing-library "^1.0.0"
-    wait-for-expect "0.4.0"
+    dom-testing-library "^2.3.1"
+    wait-for-expect "^0.5.0"
 
 react@^16.3.1:
   version "16.3.1"
@@ -3285,6 +3322,13 @@ realpath-native@^1.0.0:
   resolved "https://registry.yarnpkg.com/realpath-native/-/realpath-native-1.0.0.tgz#7885721a83b43bd5327609f0ddecb2482305fdf0"
   dependencies:
     util.promisify "^1.0.0"
+
+redent@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/redent/-/redent-2.0.0.tgz#c1b2007b42d57eb1389079b3c8333639d5e1ccaa"
+  dependencies:
+    indent-string "^3.0.0"
+    strip-indent "^2.0.0"
 
 regenerate-unicode-properties@^5.1.1:
   version "5.1.3"
@@ -3611,6 +3655,16 @@ source-map-resolve@^0.5.0:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
+source-map-resolve@^0.5.1:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.2.tgz#72e2cc34095543e43b2c62b2c4c10d4a9054f259"
+  dependencies:
+    atob "^2.1.1"
+    decode-uri-component "^0.2.0"
+    resolve-url "^0.2.1"
+    source-map-url "^0.4.0"
+    urix "^0.1.0"
+
 source-map-support@^0.4.15:
   version "0.4.18"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.18.tgz#0286a6de8be42641338594e97ccea75f0a2c585f"
@@ -3626,6 +3680,12 @@ source-map-support@^0.5.0:
 source-map-url@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
+
+source-map@^0.1.38:
+  version "0.1.43"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.1.43.tgz#c24bc146ca517c1471f5dacbe2571b2b7f9e3346"
+  dependencies:
+    amdefine ">=0.0.4"
 
 source-map@^0.4.4:
   version "0.4.4"
@@ -3759,6 +3819,10 @@ strip-bom@^2.0.0:
 strip-eof@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
+
+strip-indent@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
 
 strip-json-comments@~2.0.1:
   version "2.0.1"
@@ -3987,9 +4051,13 @@ w3c-hr-time@^1.0.1:
   dependencies:
     browser-process-hrtime "^0.1.2"
 
-wait-for-expect@0.4.0, wait-for-expect@^0.4.0:
+wait-for-expect@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/wait-for-expect/-/wait-for-expect-0.4.0.tgz#341c96ab89d6102a0169a9be6cd0de354de92c17"
+
+wait-for-expect@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/wait-for-expect/-/wait-for-expect-0.5.0.tgz#cc935a94c6039967bd7760c9e9cc557f4674887a"
 
 walker@~1.0.5:
   version "1.0.7"


### PR DESCRIPTION
Allows Provider components to set the initial state value. This is required for some use cases where the initial state is provided through props.

This only _initializes_ the state when the Provider mounts. If the `initialState` prop is updated it's ignored.