### PR TITLE
[react-copy-write] provide snapshot of state to mutate callback

### DIFF
--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -294,4 +294,37 @@ describe("copy-on-write-store", () => {
     setFoo("FOO");
     expect(log).toEqual(["Render Foo: FOO", "Render Bar: FOObar"]);
   });
+
+  it("mutate with current state", () => {
+    const log = [];
+    let updater;
+    class App extends React.Component {
+      render() {
+        return (
+          <Provider>
+            <div>
+              <Consumer>
+                {([state], update) => {
+                  log.push(state);
+                  updater = update;
+                  return null;
+                }}
+              </Consumer>
+            </div>
+          </Provider>
+        );
+      }
+    }
+    render(<App />);
+    // First render is the base state
+    expect(log).toEqual([baseState]);
+    updater((draft, state) => {
+      draft.user.id = state.user.id + 1;
+    });
+    // Second render should have the updated user.id
+    expect(log[1].user.id).toBe(43);
+    // Other fields shouldn't have been updated
+    expect(log[0].posts).toEqual(log[1].posts);
+  });
+
 });

--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,6 @@ export default function createCopyOnWriteState(baseState) {
    */
   let currentState = baseState;
   let providerListener = null;
-  // $FlowFixMe React.createContext exists now
   const State = React.createContext(baseState);
   // Wraps immer's produce. Only notifies the Provider
   // if the returned draft has been changed.
@@ -40,7 +39,7 @@ export default function createCopyOnWriteState(baseState) {
         `the returned Provider, and/or delay your mutate calls until the component ` +
         `tree is moutned.`
     );
-    const nextState = produce(currentState, fn);
+    const nextState = produce(currentState, draft => fn(draft, currentState));
     if (nextState !== currentState) {
       currentState = nextState;
       providerListener();


### PR DESCRIPTION
Sometimes we want to read the current state during mutation, and it's expensive to read from the draft `Proxy` object according to `immer`, thus providing the current state to the mutator callback