### PR TITLE
Add consume prop, rename selectors to select

### DIFF
--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -103,20 +103,20 @@ describe("copy-on-write-store", () => {
       render() {
         return (
           <Provider>
-            <Consumer selectors={[state => state.user]}>
+            <Consumer select={[state => state.user]}>
               {([user], update) => {
                 log.push("Render User");
                 updater = update;
                 return null;
               }}
             </Consumer>
-            <Consumer selectors={[state => state.posts]}>
+            <Consumer select={[state => state.posts]}>
               {([posts]) => {
                 log.push("Render Posts");
                 return null;
               }}
             </Consumer>
-            <Consumer selectors={[state => state]}>
+            <Consumer select={[state => state]}>
               {([state]) => {
                 log.push("Render State");
                 return null;
@@ -141,7 +141,7 @@ describe("copy-on-write-store", () => {
     let updater;
 
     const UserPosts = ({ children }) => (
-      <Consumer selectors={[state => state.user.id, state => state.posts]}>
+      <Consumer select={[state => state.user.id, state => state.posts]}>
         {([userID, posts]) => {
           const userPosts = posts.filter(post => post.authorID === userID);
           return children(userPosts);
@@ -200,7 +200,7 @@ describe("copy-on-write-store", () => {
         return (
           <Provider>
             <div>
-              <Consumer selectors={[state => state.items]}>
+              <Consumer select={[state => state.items]}>
                 {([items]) => {
                   log.push(items.join());
                   return null;
@@ -230,7 +230,7 @@ describe("copy-on-write-store", () => {
     const App = ({ initialState }) => (
       <Provider initialState={initialState}>
         <div>
-          <Consumer selectors={[state => state.items]}>
+          <Consumer select={[state => state.items]}>
             {([items]) => {
               log.push(items.join());
               return null;
@@ -249,7 +249,7 @@ describe("copy-on-write-store", () => {
     expect(log).toEqual(["1,2,3,4"]);
   });
 
-  it("memoizeWith", () => {
+  it("consume", () => {
     const { Provider, Consumer, mutate } = createState({
       foo: "foo",
       bar: "bar",
@@ -269,15 +269,15 @@ describe("copy-on-write-store", () => {
     const App = ({ memoize }) => (
       <Provider>
         <div>
-          <Consumer selectors={[state => state.baz]}>
+          <Consumer select={[state => state.baz]}>
             {([baz]) => (
-              <Consumer memoizeWith={{ baz }} selectors={[state => state.foo]}>
+              <Consumer consume={{ baz }} select={[state => state.foo]}>
                 {([foo]) => {
                   log.push("Render Foo: " + foo);
                   const barProps =
-                    memoize === false ? { memoizeWith: { foo } } : {};
+                    memoize === false ? { consume: { foo } } : {};
                   return (
-                    <Consumer {...barProps} selectors={[state => state.bar]}>
+                    <Consumer {...barProps} select={[state => state.bar]}>
                       {([bar]) => {
                         log.push("Render Bar: " + foo + bar);
                         return null;
@@ -306,7 +306,7 @@ describe("copy-on-write-store", () => {
     expect(log).toEqual(["Render Foo: FOO", "Render Bar: FOObar"]);
     log = [];
     setBaz("BAZ");
-    // Only Foo should re-render, since its memoizeWith baz
+    // Only Foo should re-render, since it consumes baz
     expect(log).toEqual(["Render Foo: FOO"]);
   });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -82,17 +82,17 @@ export default function createCopyOnWriteState(baseState) {
   }
 
   class ConsumerMemoization extends React.Component {
-    shouldComponentUpdate({ state, memoizeWith }) {
+    shouldComponentUpdate({ state, consume }) {
       const currentState = this.props.state;
-      const currentMemoizeWith = this.props.memoizeWith;
+      const currentConsume = this.props.consume;
       const hasStateChanged = state.some(
         (observedState, i) => observedState !== currentState[i]
       );
-      if (hasStateChanged || memoizeWith === null) {
+      if (hasStateChanged || consume === null) {
         return hasStateChanged;
       }
-      return Object.keys(memoizeWith).some(
-        key => memoizeWith[key] !== currentMemoizeWith[key]
+      return Object.keys(consume).some(
+        key => consume[key] !== currentConsume[key]
       );
     }
 
@@ -104,15 +104,15 @@ export default function createCopyOnWriteState(baseState) {
 
   class CopyOnWriteConsumer extends React.Component {
     static defaultProps = {
-      selectors: [identityFn],
-      memoizeWith: null
+      select: [identityFn],
+      consume: null
     };
 
     consumer = state => {
-      const { children, selectors, memoizeWith } = this.props;
-      const observedState = selectors.map(fn => fn(state));
+      const { children, select, consume } = this.props;
+      const observedState = select.map(fn => fn(state));
       return (
-        <ConsumerMemoization memoizeWith={memoizeWith} state={observedState}>
+        <ConsumerMemoization consume={consume} state={observedState}>
           {children}
         </ConsumerMemoization>
       );


### PR DESCRIPTION
`consume` is a better API than `memoize` because it can prevent re-renders from unrelated state updates and unrelated prop updates. It lets the Consumer say "here are some values that I consume"

I also renamed `selectors` to `select` so that it's language consistent (consume this, select this)