### PR TITLE
Add createSelector export

### DIFF
--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -342,4 +342,21 @@ describe("copy-on-write-store", () => {
     expect(log[0].posts).toEqual(log[1].posts);
   });
 
+  it("createSelector", () => {
+    let log = [];
+    const { createSelector, Provider, Consumer } = createState({ foo: "foo" });
+    const fooSelector = createSelector(state => state.foo);
+    const App = () => (
+      <Provider>
+        <Consumer select={[fooSelector]}>
+          {([foo]) => {
+            log.push(foo);
+            return null;
+          }}
+        </Consumer>
+      </Provider>
+    );
+    render(<App />);
+    expect(log).toEqual(["foo"]);
+  });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -46,6 +46,18 @@ export default function createCopyOnWriteState(baseState) {
     }
   }
 
+  /**
+   * Currently createSelector is just the identity function. The long-term
+   * goal is for it to be a way to create optimizable selectors using React's
+   * unstable_observedBits Context API. The implementation of that
+   * optimization strategy is currently still in development, but I want people
+   * to start using createSelector now. Then, when it *does* get optimized, there
+   * will be changes required from users.
+   */
+  function createSelector(fn) {
+    return fn;
+  }
+
   class CopyOnWriteStoreProvider extends React.Component {
     state = this.props.initialState || currentState;
 
@@ -125,6 +137,7 @@ export default function createCopyOnWriteState(baseState) {
   return {
     Provider: CopyOnWriteStoreProvider,
     Consumer: CopyOnWriteConsumer,
-    mutate
+    mutate,
+    createSelector
   };
 }


### PR DESCRIPTION
This will be the recommended way to create selectors that can be optimized. Right now I'm not sure how I want to do that (#9 is the first attempt, but it's I think its over-engineered)

I want people to start using `createSelector` now, so that I can enable optimizations in the future. So just export a dummy version of it for now.