### PR TITLE
Remove mutate from render callback, stop using tuples for state

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -108,7 +108,7 @@ export default function createCopyOnWriteState(baseState) {
 
     render() {
       const { children, state } = this.props;
-      return children(state, mutate);
+      return children.apply(null, state);
     }
   }
 


### PR DESCRIPTION
Since `mutate` is exposed at the top-level from `createSelector` it doesn't make a lot of sense to include it in the render callback.

This change lets us pass in selected state as arguments instead of using an array all the time (woo!)