### PR TITLE
[rcw] add flow typing

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -7,5 +7,8 @@
 [lints]
 
 [options]
+suppress_type=$FlowExpectedError
+
+suppress_comment=\\(.\\|\n\\)*\\$FlowExpectedError
 
 [strict]

--- a/__tests__/index-flowtest.js
+++ b/__tests__/index-flowtest.js
@@ -1,0 +1,94 @@
+/**
+ * @flow strict-local
+ * @format
+ */
+
+import React from 'react';
+import type { Store } from '../src/index.js';
+import createStore from '../src/index.js';
+
+type User = { name: string, age: number };
+type State = {
+  users: Array<User>,
+  version: number,
+};
+
+const store: Store<State> = createStore(
+  ({
+    users: [],
+    version: 100,
+  }: State),
+);
+
+const { Provider, Consumer, mutate } = store;
+
+function testProvider() {
+  return (
+    <Provider initialState={{ users: [], version: 100 }}>
+      <div>test</div>
+    </Provider>
+  );
+}
+
+function testProviderWithIncorrectInitialState() {
+  return (
+    // $FlowExpectedError
+    <Provider initialState={{ users: 123 }}>
+      <div>test</div>
+    </Provider>
+  );
+}
+
+function testConsumer() {
+  return (
+    <Consumer select={[state => state.users, state => state.version]}>
+      {(users, version) => {
+        const a: Array<User> = users;
+        const b: number = version;
+        return <div>test</div>;
+      }}
+    </Consumer>
+  );
+}
+
+function testConsumerWithObjectSelector() {
+  return (
+    <Consumer select={[state => state]}>
+      {({ users, version }) => {
+        const a: Array<User> = users;
+        const b: number = version;
+        return <div>test</div>;
+      }}
+    </Consumer>
+  );
+}
+
+function testIncorrectConsumer() {
+  return (
+    <Consumer select={[state => state.users, state => state.version]}>
+      {(users, version) => {
+        // $FlowExpectedError
+        const a: number = users;
+        // $FlowExpectedError
+        const b: string = version;
+        return <div>test</div>;
+      }}
+    </Consumer>
+  );
+}
+
+function testMutate() {
+  mutate((draft, state) => {
+    draft.users = [{ name: 'shengmin', age: 20 }];
+    draft.version = state.version + 1;
+  });
+}
+
+function testIncorrectMutate() {
+  mutate((draft, state) => {
+    // $FlowExpectedError
+    draft.users = '';
+    // $FlowExpectedError
+    draft.version = state.versions + 1;
+  });
+}

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@babel/preset-react": "^7.0.0-beta.44",
     "babel-core": "^7.0.0-0",
     "babel-jest": "^22.4.3",
-    "flow-bin": "^0.69.0",
+    "flow-bin": "^0.77.0",
     "jest": "^22.4.3",
     "prettier": "^1.12.0",
     "react": "^16.3.1",

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -1,0 +1,50 @@
+/**
+ * @flow strict-local
+ * @format
+ */
+
+// recipe takes in a virtual object (ie. Proxy) representing the current state,
+// tracks all mutation performed on the state behind the scene.
+// All mutations are then 'replayed' to construct the new state with as much
+// structural sharing as possible
+// `state` is the read-only snapshot of the state before the mutation
+export type Recipe<T> = (draft: T, state: $ReadOnly<T>) => void;
+export type Mutate<T> = (recipe: Recipe<T>) => void;
+
+type ConsumerRender<S> = (...S) => React$Node;
+
+type ProviderProps<T> = {|
+  children: React$Node,
+  initialState?: T,
+|};
+
+export type Provider<T> = React$ComponentType<ProviderProps<T>>;
+
+type GetReturnType = <T, S>((T) => S) => S;
+
+type ConsumerProps<T, TSelect: $ReadOnlyArray<(T) => mixed>> = {|
+  // An array of selectors that select a subset of relevant store state
+  // that gets passed to the `render` or `children` callback
+  select?: TSelect,
+  children?: ConsumerRender<$TupleMap<TSelect, GetReturnType>>,
+  render?: ConsumerRender<$TupleMap<TSelect, GetReturnType>>,
+|};
+
+type Selector<T, R> = T => R;
+
+export type Store<T> = {
+  +Provider: Provider<T>,
+  +Consumer: {
+    <TSelect: $ReadOnlyArray<(T) => mixed>>(
+      ConsumerProps<T, TSelect>,
+    ): React$Node,
+    // Need the following to fake this as a functional component
+    displayName?: ?string,
+    propTypes?: any,
+    contextTypes?: any,
+  },
+  +mutate: Mutate<T>,
+  createSelector<R>(Selector<T, R>): Selector<T, R>,
+};
+
+declare export default function createStore<T>(baseState: T): Store<T>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1645,9 +1645,9 @@ find-up@^2.1.0:
   dependencies:
     locate-path "^2.0.0"
 
-flow-bin@^0.69.0:
-  version "0.69.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.69.0.tgz#053159a684a6051fcbf0b71a2eb19a9679082da6"
+flow-bin@^0.77.0:
+  version "0.77.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.77.0.tgz#4e5c93929f289a0c28e08fb361a9734944a11297"
 
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Add the basic flow typing and bump flow version to 0.77

```
[shengmin-mbp1][~/react-copy-write] (flow) yarn run flow
Using globally installed version of Yarn
yarn run v1.5.1
$ flow
Launching Flow server for /Users/shengmin/react-copy-write
Spawned flow server (pid=30147)
Logs will go to /private/tmp/flow/zSUserszSshengminzSreact-copy-write.log
Monitor logs will go to /private/tmp/flow/zSUserszSshengminzSreact-copy-write.monitor_log
No errors!
✨  Done in 5.59s.
```