### PR TITLE
Publish Flow defintions

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "flow": "flow",
     "test": "jest",
-    "build": "babel src --out-dir lib",
+    "build": "babel src --out-dir lib --copy-files",
     "prepare": "npm run build",
     "prettier": "prettier --write \"{src,__tests__}/**/*.js\""
   },


### PR DESCRIPTION
Hi,

in order for Flow to find the type definitions they must be exported alongside the compiled sources.
Since there are only those two files in `src` a simple `--copy-files` from Babel should do it.


