### PR TITLE
Remove fbjs dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
   },
   "dependencies": {
     "create-react-context": "^0.2.2",
-    "fbjs": "^0.8.16",
     "immer": "^1.2.1",
-    "invariant": "^2.2.4"
+    "invariant": "^2.2.4",
+    "shallowequal": "^1.1.0"
   },
   "peerDependencies": {
     "react": "^16.3.0"
@@ -32,8 +32,8 @@
     "flow-bin": "^0.77.0",
     "jest": "^22.4.3",
     "prettier": "^1.12.0",
-    "react": "^16.3.1",
-    "react-dom": "^16.3.1",
+    "react": "^16.5.0",
+    "react-dom": "^16.5.0",
     "react-testing-library": "^3.1.4",
     "regenerator-runtime": "^0.11.1"
   }

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@
 import React, { Component } from "react";
 import produce from "immer";
 import invariant from "invariant";
-import shallowEqual from "fbjs/lib/shallowEqual";
+import shallowEqual from "shallowequal";
 import createContext from 'create-react-context'
 
 // The default selector is the identity function

--- a/yarn.lock
+++ b/yarn.lock
@@ -1609,18 +1609,6 @@ fbjs@^0.8.0:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.18"
 
-fbjs@^0.8.16:
-  version "0.8.16"
-  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
-  dependencies:
-    core-js "^1.0.0"
-    isomorphic-fetch "^2.1.1"
-    loose-envify "^1.0.0"
-    object-assign "^4.1.0"
-    promise "^7.1.1"
-    setimmediate "^1.0.5"
-    ua-parser-js "^0.7.9"
-
 filename-regex@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/filename-regex/-/filename-regex-2.0.1.tgz#c1c4b9bee3e09725ddb106b75c1e301fe2f18b26"
@@ -3235,11 +3223,10 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.6.0:
-  version "15.6.1"
-  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
+prop-types@^15.6.2:
+  version "15.6.2"
+  resolved "https://mirrors.gandi.net/npm/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
   dependencies:
-    fbjs "^0.8.16"
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
@@ -3279,14 +3266,14 @@ rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-dom@^16.3.1:
-  version "16.3.1"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.3.1.tgz#6a3c90a4fb62f915bdbcf6204422d93a7d4ca573"
+react-dom@^16.5.0:
+  version "16.5.0"
+  resolved "https://mirrors.gandi.net/npm/react-dom/-/react-dom-16.5.0.tgz#57704e5718669374b182a17ea79a6d24922cb27d"
   dependencies:
-    fbjs "^0.8.16"
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    prop-types "^15.6.0"
+    prop-types "^15.6.2"
+    schedule "^0.3.0"
 
 react-testing-library@^3.1.4:
   version "3.1.4"
@@ -3295,14 +3282,14 @@ react-testing-library@^3.1.4:
     dom-testing-library "^2.3.1"
     wait-for-expect "^0.5.0"
 
-react@^16.3.1:
-  version "16.3.1"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.3.1.tgz#4a2da433d471251c69b6033ada30e2ed1202cfd8"
+react@^16.5.0:
+  version "16.5.0"
+  resolved "https://mirrors.gandi.net/npm/react/-/react-16.5.0.tgz#f2c1e754bf9751a549d9c6d9aca41905beb56575"
   dependencies:
-    fbjs "^0.8.16"
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    prop-types "^15.6.0"
+    prop-types "^15.6.2"
+    schedule "^0.3.0"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"
@@ -3573,6 +3560,12 @@ sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
 
+schedule@^0.3.0:
+  version "0.3.0"
+  resolved "https://mirrors.gandi.net/npm/schedule/-/schedule-0.3.0.tgz#1be2ab2fc2e768536269ce7326efb478d6c045e8"
+  dependencies:
+    object-assign "^4.1.1"
+
 "semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
@@ -3606,6 +3599,10 @@ set-value@^2.0.0:
 setimmediate@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
+
+shallowequal@^1.1.0:
+  version "1.1.0"
+  resolved "https://mirrors.gandi.net/npm/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
 
 shebang-command@^1.2.0:
   version "1.2.0"
@@ -3975,10 +3972,6 @@ type-check@~0.3.2:
 ua-parser-js@^0.7.18:
   version "0.7.18"
   resolved "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.18.tgz#a7bfd92f56edfb117083b69e31d2aa8882d4b1ed"
-
-ua-parser-js@^0.7.9:
-  version "0.7.17"
-  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.17.tgz#e9ec5f9498b9ec910e7ae3ac626a805c4d09ecac"
 
 uglify-js@^2.6:
   version "2.8.29"


### PR DESCRIPTION
Hi,

following the changes in React core:
- https://github.com/facebook/react/pull/13069 
- https://github.com/facebook/prop-types/pull/194 

I thought it would make sense here as well.

So use the smaller [shallowequal](https://github.com/dashed/shallowequal) package instead.

Also maybe wait until the [same PR on creact-react-context](https://github.com/jamiebuilds/create-react-context/pull/22) get merged/published.